### PR TITLE
Migrate project to .NET 9

### DIFF
--- a/AnnotationApp/AnnotationApp.csproj
+++ b/AnnotationApp/AnnotationApp.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- Updated to target .NET 9 across mobile and desktop platforms -->
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The project is located in the `AnnotationApp` folder. It showcases how to load a
 
 ## Building the app
 
-Install the required .NET MAUI workload and restore NuGet packages. Then open the solution in Visual Studio or run `dotnet build`.
+Install the required .NET MAUI workload for .NET 9 and restore NuGet packages. Then open the solution in Visual Studio or run `dotnet build`.


### PR DESCRIPTION
## Summary
- target .NET 9 frameworks
- update build instructions to mention .NET 9

## Testing
- `dotnet build AnnotationApp/AnnotationApp.csproj -c Release` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed1c8b3e883258b4bb5d3bd3b3f73